### PR TITLE
Bruk eclipse-temurin i stedet for openjdk som base image

### DIFF
--- a/imongr/Dockerfile
+++ b/imongr/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM eclipse-temurin:8-jre-jammy
 
 RUN mkdir -p /opt/shinyproxy/ \
   && wget --progress=dot:giga https://www.shinyproxy.io/downloads/shinyproxy-2.6.1.jar -O /opt/shinyproxy/shinyproxy.jar


### PR DESCRIPTION
openjdk oppdateres ikke lenger, og inneholder derfor sårbarheter.

Closes #25