### PR TITLE
Sett bruker til docker for shinyproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Repeat the above steps on all nodes.
 ## Start and stop service
 To enable _shinyproxy_ use _docker compose_ to start the relevant services in detached mode. Move into the _shinyproxy_ directory and run:
 ```
+export DOCKERID=$(getent group docker | cut -d: -f3) # to get access to run docker daemon
 docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ docker system prune
 ```
 Finally, bring up the updated _shinyproxy_ container:
 ```
+export DOCKERID=$(getent group docker | cut -d: -f3)
 docker compose up -d
 ```
 

--- a/imongr/docker-compose.yml
+++ b/imongr/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: hnskde/shinyproxy-imongr
     restart: unless-stopped
     container_name: shinyproxy
+    user: ":${DOCKERID}"
     environment:
       IMONGR_DB_HOST: ${IMONGR_DB_HOST}
       IMONGR_DB_HOST_VERIFY: ${IMONGR_DB_HOST_VERIFY}


### PR DESCRIPTION
Det manglet rettigheter til docker deamon ved kjøring av shinyproxy sitt eget docker-image. Ser ut til å fungere med 
`user: ":${DOCKERID}"`. `DOCKERID` må defineres som en miljøvariabel før kjøring av `docker compose`