### PR TITLE
Use image-pull-policy: Always

### DIFF
--- a/imongr/application.yml
+++ b/imongr/application.yml
@@ -17,6 +17,7 @@ proxy:
     logout-url: https://login-imongr.skde.org/logout?client_id=${OPENID_CLIENT_ID}&logout_uri=https://imongr.skde.no/logout-success
   docker:
     internal-networking: true
+    image-pull-policy: Always
   container-log-path: s3://shinyproxy-apps-log
   container-log-s3-access-key: ${AWS_S3_ACCESS_KEY}
   container-log-s3-access-secret: ${AWS_S3_ACCESS_SECRET}


### PR DESCRIPTION
Will pull latest version of docker image automatically. New feature in ShinyProxy 3