### PR TITLE
Oppdater til shinyproxy fra 3.0.2 til 3.1.1.

### DIFF
--- a/imongr/Dockerfile
+++ b/imongr/Dockerfile
@@ -1,7 +1,7 @@
-FROM eclipse-temurin:8-jre-jammy
+FROM eclipse-temurin:21.0.3_9-jre-jammy
 
 RUN mkdir -p /opt/shinyproxy/ \
-  && wget --progress=dot:giga https://www.shinyproxy.io/downloads/shinyproxy-3.0.2.jar -O /opt/shinyproxy/shinyproxy.jar
+  && wget --progress=dot:giga https://www.shinyproxy.io/downloads/shinyproxy-3.1.1.jar -O /opt/shinyproxy/shinyproxy.jar
 COPY application.yml /opt/shinyproxy/application.yml
 ADD https://raw.githubusercontent.com/mong/imongr/main/pkgdown/favicon/favicon.ico /opt/shinyproxy/
 


### PR DESCRIPTION
Oppdaterer samtidig java (JDK) fra 8 til 21. Shinyproxy fungerte ikke med gammel java

Closes #47 and #38